### PR TITLE
Fix for #164 requests.get() called multiple times even on valid response

### DIFF
--- a/secedgar/client/network_client.py
+++ b/secedgar/client/network_client.py
@@ -163,6 +163,7 @@ class NetworkClient(AbstractClient):
             response = requests.get(prepared_url, params=params, **kwargs)
             try:
                 self._validate_response(response)
+                break
             except EDGARQueryError as e:
                 # Raise query error if on last retry
                 if i == self.retry_count:


### PR DESCRIPTION
- Fix for #164 NetworkClient.get_response() calls requests.get() multiple times even on valid response .

